### PR TITLE
Remove Screenr functionality as the service is defunct

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -105,10 +105,6 @@ class filter_oembed extends moodle_text_filter {
             $search = '/<a\s[^>]*href="(https?:\/\/(www\.)?)(issuu\.com)\/(.*?)"(.*?)>(.*?)<\/a>/is';
             $newtext = preg_replace_callback($search, 'filter_oembed_issuucallback', $newtext);
         }
-        if (get_config('filter_oembed', 'screenr')) {
-            $search = '/<a\s[^>]*href="(https?:\/\/(www\.)?)(screenr\.com)\/(.*?)"(.*?)>(.*?)<\/a>/is';
-            $newtext = preg_replace_callback($search, 'filter_oembed_screenrcallback', $newtext);
-        }
         if (get_config('filter_oembed', 'soundcloud')) {
             $search = '/<a\s[^>]*href="(https?:\/\/(www\.)?)(soundcloud\.com)\/(.*?)"(.*?)>(.*?)<\/a>/is';
             $newtext = preg_replace_callback($search, 'filter_oembed_soundcloudcallback', $newtext);
@@ -230,19 +226,6 @@ function filter_oembed_issuucallback($link) {
     $url = "http://issuu.com/oembed?url=".trim($link[1]).trim($link[3]).'/'.trim($link[4])."&format=json";
     $json = filter_oembed_curlcall($url);
     return $json === null ? '<h3>'. get_string('connection_error', 'filter_oembed') .'</h3>' : $json['html'];
-}
-
-/**
- * Looks for links pointing to Screenr content and processes them.
- *
- * @param $link HTML tag containing a link
- * @return string HTML content after processing.
- */
-function filter_oembed_screenrcallback($link) {
-    global $CFG;
-    $url = "http://www.screenr.com/api/oembed.json?url=".trim($link[1]).trim($link[3]).'/'.trim($link[4]).'&maxwidth=480&maxheight=270';
-    $json = filter_oembed_curlcall($url);
-    return filter_oembed_vidembed($json);
 }
 
 /**

--- a/lang/en/filter_oembed.php
+++ b/lang/en/filter_oembed.php
@@ -32,7 +32,6 @@ $string['ted'] = 'Ted Talks';
 $string['slideshare'] = 'SlideShare';
 $string['officemix'] = 'Office Mix';
 $string['issuu'] = 'Issuu';
-$string['screenr'] = 'Screenr';
 $string['soundcloud'] = 'SoundCloud';
 $string['pollev'] = 'Poll Everywhere';
 $string['lazyload'] = 'Delay Embed Loading (Lazyload)';

--- a/settings.php
+++ b/settings.php
@@ -39,8 +39,6 @@ if ($ADMIN->fulltree) {
     $settings->add($item);
     $item = new admin_setting_configselect('filter_oembed/officemix', get_string('officemix', 'filter_oembed'), '', 1, $torf);
     $settings->add($item);
-    $item = new admin_setting_configselect('filter_oembed/screenr', get_string('screenr', 'filter_oembed'), '', 1, $torf);
-    $settings->add($item);
     $item = new admin_setting_configselect('filter_oembed/issuu', get_string('issuu', 'filter_oembed'), '', 1, $torf);
     $settings->add($item);
     $item = new admin_setting_configselect('filter_oembed/soundcloud', get_string('soundcloud', 'filter_oembed'), '', 1, $torf);

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -53,11 +53,10 @@ class filter_oembed_testcase extends basic_testcase {
         $tedlink = '<p><a href="https://www.ted.com/talks/aj_jacobs_how_healthy_living_nearly_killed_me">Ted</a></p>';
         $slidesharelink = '<p><a href="http://www.slideshare.net/timbrown/ideo-values-slideshare1">slideshare</a></p>';
         $issuulink = '<p><a href="http://issuu.com/hujawes/docs/dehorew">issuu</a></p>';
-        $screenrlink = '<p><a href="https://www.screenr.com/wxVH">screenr</a></p>';
         $polleverywherelink = '<p><a href="https://www.polleverywhere.com/multiple_choice_polls/AyCp2jkJ2HqYKXc/web">';
         $polleverywherelink .= '$popolleverywhere</a></p>';
 
-        $filterinput = $souncloudlink.$youtubelink.$officemixlink.$vimeolink.$tedlink.$slidesharelink.$issuulink.$screenrlink;
+        $filterinput = $souncloudlink.$youtubelink.$officemixlink.$vimeolink.$tedlink.$slidesharelink.$issuulink;
         $filterinput .= $polleverywherelink;
 
         $filteroutput = $this->filter->filter($filterinput);
@@ -88,9 +87,6 @@ class filter_oembed_testcase extends basic_testcase {
         $issuuoutput .= ' class="issuuembed"></div><script type="text/javascript" src="//e.issuu.com/embed.js" async="true">';
         $issuuoutput .= '</script>';
         $this->assertContains($issuuoutput, $filteroutput, 'Issuu filter fails');
-
-        $screenroutput = '<iframe src="https://www.screenr.com/embed/wxVH" width="650" height="396" frameborder="0"></iframe>';
-        $this->assertContains($screenroutput, $filteroutput, 'Screenr filter fails');
 
         $polleverywhereoutput = '<script src="http://www.polleverywhere.com/multiple_choice_polls/AyCp2jkJ2HqYKXc/web.js';
         $polleverywhereoutput .= '?results_count_format=percent"></script>';

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2015060100;
+$plugin->version = 2015111800;
 $plugin->requires = 2015051100;
 $plugin->component = 'filter_oembed';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Screenr is shut down, it's no longer serving content.  Removing Screenr functionality form the plugin
