### PR TITLE
Poet v30.0.0.3 Fixes for codechecker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+php:
+ - 5.4
+ - 5.5
+ - 5.6
+ - 7.0
+
+env:
+ global:
+  - MOODLE_BRANCH=MOODLE_30_STABLE
+ matrix:
+  - DB=pgsql
+  - DB=mysqli
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer selfupdate
+  - composer create-project -n --no-dev moodlerooms/moodle-plugin-ci ci ^1
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci csslint
+  - moodle-plugin-ci shifter
+  - moodle-plugin-ci jshint
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ cache:
     - $HOME/.composer/cache
 
 php:
- - 5.4
- - 5.5
  - 5.6
  - 7.0
 
 env:
  global:
   - MOODLE_BRANCH=MOODLE_30_STABLE
+
  matrix:
   - DB=pgsql
   - DB=mysqli

--- a/db/install.php
+++ b/db/install.php
@@ -20,9 +20,9 @@
  * @package   filter_oembed
  * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * code based on the following filters... 
+ * code based on the following filters...
  * Screencast (Mark Schall)
- * Soundcloud (Troy Williams) 
+ * Soundcloud (Troy Williams)
  */
 
 /**

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -20,9 +20,9 @@
  * @package   filter_oembed
  * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * code based on the following filters... 
+ * code based on the following filters...
  * Screencast (Mark Schall)
- * Soundcloud (Troy Williams) 
+ * Soundcloud (Troy Williams)
  */
 
 /**

--- a/filter.php
+++ b/filter.php
@@ -72,11 +72,11 @@ class filter_oembed extends moodle_text_filter {
             // Non string data can not be filtered anyway.
             return $text;
         }
-//        if (get_user_device_type() !== 'default'){
+        // if (get_user_device_type() !== 'default'){
             // no lazy video on mobile
             // return $text;
 
-//        }
+        // }
         if (stripos($text, '</a>') === false) {
             // Performance shortcut - all regexes below end with the </a> tag.
             // If not present nothing can match.

--- a/lang/cs/filter_oembed.php
+++ b/lang/cs/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'Filtr oEmbed';
 $string['youtube'] = 'Youtube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/de/filter_oembed.php
+++ b/lang/de/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'oEmbed-Filter';
 $string['youtube'] = 'YouTube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/en/filter_oembed.php
+++ b/lang/en/filter_oembed.php
@@ -1,23 +1,23 @@
 <?php
-// This file is part of Moodle-clickview-Filter
+// This file is part of Moodle-oembed-Filter
 //
-// Moodle-clickview-Filter is free software: you can redistribute it and/or modify
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// Moodle-clickview-Filter is distributed in the hope that it will be useful,
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle-clickview-Filter.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Filter for component 'filter_clickview'
+ * Filter for component 'filter_oembed'
  *
- * @package   filter_clickview
+ * @package   filter_oembed
  * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * code based on the following filters...

--- a/lang/es/filter_oembed.php
+++ b/lang/es/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'oEmbed Filter';
 $string['youtube'] = 'Youtube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/fi/filter_oembed.php
+++ b/lang/fi/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'oEmbed-suodatin';
 $string['youtube'] = 'YouTube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/fr/filter_oembed.php
+++ b/lang/fr/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'Filtre oEmbed';
 $string['youtube'] = 'Youtube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/it/filter_oembed.php
+++ b/lang/it/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'Filtro oEmbed';
 $string['youtube'] = 'Youtube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/ja/filter_oembed.php
+++ b/lang/ja/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'oEmbedフィルタ';
 $string['youtube'] = 'Youtube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/nl/filter_oembed.php
+++ b/lang/nl/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'oEmbed Filter';
 $string['youtube'] = 'YouTube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/pl/filter_oembed.php
+++ b/lang/pl/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'oEmbed Filter';
 $string['youtube'] = 'Youtube';
 $string['vimeo'] = 'Vimeo';

--- a/lang/pt_br/filter_oembed.php
+++ b/lang/pt_br/filter_oembed.php
@@ -1,4 +1,30 @@
 <?php
+// This file is part of Moodle-oembed-Filter
+//
+// Moodle-oembed-Filter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle-oembed-Filter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle-oembed-Filter.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filter for component 'filter_oembed'
+ *
+ * @package   filter_oembed
+ * @copyright 2012 Matthew Cannings; modified 2015 by Microsoft Open Technologies, Inc.
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * code based on the following filters...
+ * Screencast (Mark Schall)
+ * Soundcloud (Troy Williams)
+ */
+
 $string['filtername'] = 'Filtro oEmbed';
 $string['youtube'] = 'YouTube';
 $string['vimeo'] = 'Vimeo';


### PR DESCRIPTION
Hi. I have run the plugin through an auto-fix for Moodle code guideline violations that can be fixed automatically. You can see the results of the codechecker with these fixes here - https://travis-ci.org/POETGroup/moodle-filter_oembed/builds/116711611.
There are still some identified problems, although the uppercase global seems to be a problem with the Moodle codechecker. I don't know why it is saying that is not allowed.
Anyway, if these are merged in, I can change some of the review posted here - https://moodle.org/plugins/reviews.php?version=10714&review=50
